### PR TITLE
add time-frequency visualization to cphd_validation_tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.1.24]
+### Added
+- Time-frequency visualization to `cphd_validation_tool`
+
 ## [1.1.23] - 2023-07-28
 ### Added
 - Added button to generate KMZ file to cphd_validation_tool.

--- a/sarpy_apps/apps/cphd_validation_tool.py
+++ b/sarpy_apps/apps/cphd_validation_tool.py
@@ -46,6 +46,7 @@ class _Buttons(WidgetPanelNoLabel):
     _widget_list = (
         ('plot_image_area_label', 'plot_image_area_button'),
         ('plot_vector_power_label', 'plot_vector_power_button'),
+        ('plot_vector_tfr_label', 'plot_vector_tfr_button'),
         ('kmz_label', 'kmz_button'),
     )
 
@@ -61,6 +62,13 @@ class _Buttons(WidgetPanelNoLabel):
         docstring='')  # type: Label
     plot_vector_power_button = ButtonDescriptor(
         'plot_vector_power_button', default_text='CPHD Vector Power Plot',
+        docstring='')  # type: Button
+
+    plot_vector_tfr_label = LabelDescriptor(
+        'plot_vector_tfr_label', default_text='Plot CPHD Vector Time-Frequency Representation',
+        docstring='')  # type: Label
+    plot_vector_tfr_button = ButtonDescriptor(
+        'plot_vector_tfr_button', default_text='CPHD Vector Time-Frequency Plot',
         docstring='')  # type: Button
 
     kmz_label = LabelDescriptor(
@@ -119,7 +127,7 @@ class ValidationTool(tkinter.PanedWindow, WidgetWithMetadata):
 
         # handle packing manually
         self.button_panel = _Buttons(self)
-        self.add(self.button_panel, width=700, height=170, padx=5, pady=5, sticky=tkinter.NSEW)
+        self.add(self.button_panel, width=700, height=240, padx=5, pady=5, sticky=tkinter.NSEW)
 
         # create the scrolled text widget for logging output
         self.text_log_widget = ScrolledText(self)  # TODO: other configuration?
@@ -157,6 +165,7 @@ class ValidationTool(tkinter.PanedWindow, WidgetWithMetadata):
         # set the callbacks for the button panel
         self.button_panel.plot_image_area_button.config(command=self.callback_plot_image_area)
         self.button_panel.plot_vector_power_button.config(command=self.callback_plot_vector_power)
+        self.button_panel.plot_vector_tfr_button.config(command=self.callback_plot_vector_tfr)
         self.button_panel.kmz_button.config(command=self.callback_kmz)
 
         self.update_reader(reader)
@@ -315,6 +324,18 @@ class ValidationTool(tkinter.PanedWindow, WidgetWithMetadata):
         reader = self.variables.image_reader.base_reader
         root = tkinter.Toplevel(self.master)
         cphd_plotting.CphdVectorPower(root, reader)
+
+    def callback_plot_vector_tfr(self):
+        """
+        Enable the vector TFR visualization
+        """
+
+        if not self._verify_reader():
+            return
+
+        reader = self.variables.image_reader.base_reader
+        root = tkinter.Toplevel(self.master)
+        cphd_plotting.CphdVectorTFR(root, reader)
 
     def callback_kmz(self):
         """


### PR DESCRIPTION
# Description
This PR adds a per-vector time-frequency representation visualization to `cphd_validation_tool`.

Additionally, there are some bugfixes for gracefully handling per-channel optional parameters in the existing `CphdVectorPower` class that were noticed during the implementation.

![image](https://github.com/ngageoint/sarpy_apps/assets/78438270/c4ba6af9-1b44-401c-85c1-7440dcc50c84)

Note: an attempt was made to look into sharing a code foundation with `pulse_explorer`, an existing CRSD tool that also forms time-frequency representations. We hit an impasse as there appears to be a mismatch in the CRSD reader used in `sarpy_apps` with the `sarpy` version requested in `setup.py`. Future work may fix the CRSD tooling and harmonize the tooling (likely by patterning a `crsd_validation_tool` off of the complex image and CPHD validation tools.