### PR TITLE
fix pulse_explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [1.1.24]
 ### Added
 - Time-frequency visualization to `cphd_validation_tool`
+### Fixed
+- Make `pulse_explorer` compatible with sarpy 1.3.0 changes
 
 ## [1.1.23] - 2023-07-28
 ### Added

--- a/sarpy_apps/apps/pulse_explorer.py
+++ b/sarpy_apps/apps/pulse_explorer.py
@@ -117,7 +117,11 @@ def _rf_signal(reader, index, pulse):
     crsd = reader.crsd_meta
     params = crsd.Channel.Parameters[index]
     sampling_rate = params.Fs
-    pulse_data = reader[pulse, :, index].flatten()
+    data_params = {x.Identifier: x for x in crsd.Data.Channels}[params.Identifier]
+    pulse_data = reader.read(slice(numpy.maximum(pulse, 0),
+                                   numpy.minimum(pulse + 1, data_params.NumVectors)),
+                             slice(None),
+                             index=index, squeeze=True)
     fic_rate = float(reader.read_pvp_variable('FICRate', index, pulse)[0])
     dfic0 = float(reader.read_pvp_variable('DFIC0', index, pulse)[0])
 
@@ -241,7 +245,7 @@ class STFTCanvasImageReader(CRSDTypeCanvasImageReader):
                     type(value)))
         self._base_reader = value
         # noinspection PyProtectedMember
-        self._chippers = value._get_chippers_as_tuple()
+        self._chippers = value.get_data_segment_as_tuple()
         self.index = 0
 
     @property
@@ -443,10 +447,10 @@ class DirectionWidget(Frame):
             'ToggleOn.TButton', font=('Arial', 24), foreground="black",
             background="PaleTurquoise1", width=3, sticky='CENTER')
 
-        self.button_rev = Button(self.parent, text="\u25C0", takefocus=0, style='ToggleOff.TButton')
+        self.button_rev = Button(self.parent, text="<", takefocus=0, style='ToggleOff.TButton')
         self.button_prev = Button(self.parent, text="-1", takefocus=0, style='ToggleOff.TButton')
         self.button_next = Button(self.parent, text="+1", takefocus=0, style='ToggleOff.TButton')
-        self.button_fwd = Button(self.parent, text="\u25B6", takefocus=0, style='ToggleOff.TButton')
+        self.button_fwd = Button(self.parent, text=">", takefocus=0, style='ToggleOff.TButton')
 
 
 class PulseExplorer(Frame, WidgetWithMetadata):


### PR DESCRIPTION
# Description
This PR fixes the `pulse_explorer` which was broken in 1.1.20 when the code was rendered incompatible with the incoming SarPy=1.3.0 changes.

- replace removed `_get_chippers_as_tuple` with `get_data_segment_as_tuple`
- modify retrieval of `pulse_data` to use SarPy 1.3.0+ conventions

I also replaced the unicode arrows (which may have a hard time rendering on all systems) with more standard characters:

<details>
<summary>unrendered uncode arrows</summary>

![image](https://github.com/ngageoint/sarpy_apps/assets/78438270/882a7f90-1ce6-4b85-b66d-bdf0a5739ba9)

</details>

# Demo
Here is the pulse explorer for an example CRSD made from a sentinel collect:

![image](https://github.com/ngageoint/sarpy_apps/assets/78438270/d7142e95-19c6-47b1-9bb3-0a40d6fc3594)

